### PR TITLE
OpenCV version of locateAll

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -63,22 +63,22 @@ def _load_cv2(img, grayscale=None):
         grayscale = GRAYSCALE_DEFAULT
     if isinstance(img, str):
         if grayscale:
-            img = cv2.imread(img, cv2.CV_LOAD_IMAGE_GRAYSCALE)
+            img_cv = cv2.imread(img, cv2.CV_LOAD_IMAGE_GRAYSCALE)
         else:
-            img = cv2.imread(img, cv2.CV_LOAD_IMAGE_COLOR)  # -1 gets RGBA
+            img_cv = cv2.imread(img, cv2.CV_LOAD_IMAGE_COLOR)  # -1 gets RGBA
     elif isinstance(img, numpy.ndarray):
         # don't try to convert an already-gray image
         if grayscale and len(img.shape) == 3:  # and img.shape[2] == 3:
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+            img_cv = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     elif hasattr(img, 'convert'):
         # assume its a PIL.Image, convert to cv format
-        img_ocv = numpy.array(img.convert('RGB'))
-        img = img_ocv[:, :, ::-1]  # -1 does RGB -> BGR
+        img_array = numpy.array(img.convert('RGB'))
+        img_cv = img_array[:, :, ::-1].copy()  # -1 does RGB -> BGR
         if grayscale:
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+            img_cv = cv2.cvtColor(img_cv, cv2.COLOR_BGR2GRAY)
     else:
-        raise TypeError('expected image filename, OpenCV numpy array, or PIL image')
-    return img
+        raise TypeError('expected an image filename, OpenCV numpy array, or PIL image')
+    return img_cv
 
 
 def _locateAll_opencv(needleImage, haystackImage, grayscale=None, limit=10000, region=None, step=1):

--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -20,6 +20,14 @@ import errno
 from PIL import Image
 from PIL import ImageOps
 
+try:
+    import cv2, numpy
+    useOpenCV = True
+    confidence = 0.999  # for thresholding matches in _locateAll_opencv
+except ImportError:
+    useOpenCV = False
+
+
 RUNNING_PYTHON_2 = sys.version_info[0] == 2
 
 RAISE_IF_NOT_FOUND = False
@@ -40,7 +48,78 @@ except OSError as ex:
     else:
         raise
 
-def locateAll(needleImage, haystackImage, grayscale=None, limit=None, region=None, step=1):
+
+class ImageNotFoundException(Exception):
+    pass
+
+
+def _load_cv2(img, grayscale=GRAYSCALE_DEFAULT):
+    # load images if given filename, or convert as needed to opencv
+    # TO-DO: handle RGBA images
+    if isinstance(img, str):
+        if grayscale:
+            img = cv2.imread(img, cv2.CV_LOAD_IMAGE_GRAYSCALE)
+        else:
+            img = cv2.imread(img, cv2.CV_LOAD_IMAGE_COLOR)
+    elif isinstance(img, numpy.ndarray):
+        if grayscale:
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    elif hasattr(img, 'convert'):
+        # assume its a PIL.Image, convert to cv format
+        img_ocv = numpy.array(img.convert('RGB'))
+        img = img_ocv[:, :, ::-1]  # -1 does RGB -> BGR
+        if grayscale:
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    else:
+        raise TypeError('unknown image format')
+    return img
+
+
+def _locateAll_opencv(needleImage, haystackImage, grayscale=GRAYSCALE_DEFAULT, limit=None, region=None, step=1):
+    """ faster than pure python
+        step=2 skips every other row and column, ~3x faster but less accurate
+        limitations:
+          - OpenCV 3.x & python 3.x not tested
+          - RGBA images are not handled / untested
+          - step=2 not fully tested
+    """
+    needleImage = _load_cv2(needleImage, grayscale)
+    needleHeight, needleWidth = needleImage.shape[:2]
+    haystackImage = _load_cv2(haystackImage, grayscale)
+
+    if region:
+        haystackImage = haystackImage[region[1]:region[1]+region[3],
+                                      region[0]:region[0]+region[2]]
+    else:
+        region = (0, 0)  # full image; these values used in the yield statement
+
+    if (haystackImage.shape[0] < needleImage.shape[0] or
+        haystackImage.shape[1] < needleImage.shape[1]):
+        # avoid semi-cryptic OpenCV error below if bad size
+        raise ValueError('needle dimensions exceed the haystack image (or region)')
+
+    # skip every other row and column:
+    if step == 2:
+        needleImage = needleImage[::step, ::step]
+        haystackImage = haystackImage[::step, ::step]
+
+    # do the work (from https://stackoverflow.com/questions/7670112/finding-a-subimage-inside-a-numpy-image/9253805#9253805)
+    result = cv2.matchTemplate(haystackImage, needleImage, cv2.TM_CCOEFF_NORMED)
+    match_indices = numpy.arange(result.size)[(result > confidence).flatten()]
+    unraveled = numpy.unravel_index(match_indices, result.shape)
+
+    numMatchesFound = 0
+    for y, matchx in zip(unraveled[0], unraveled[1]):
+        numMatchesFound += 1
+        yield (step * matchx + region[0], step * y + region[1], needleWidth, needleHeight)
+        if limit and numMatchesFound >= limit:
+            break
+
+    if RAISE_IF_NOT_FOUND and numMatchesFound == 0:
+        raise ImageNotFoundException('Could not locate the image.')
+
+
+def _locateAll_python(needleImage, haystackImage, grayscale=None, limit=None, region=None, step=1):
     if grayscale is None:
         grayscale = GRAYSCALE_DEFAULT
     needleFileObj = None
@@ -303,6 +382,10 @@ else:
 
 grab = screenshot # for compatibility with Pillow/PIL's ImageGrab module.
 
-
-class ImageNotFoundException(Exception):
-    pass
+# set the locateAll function to use opencv if possible; python 3 needs opencv 3.0+
+if useOpenCV:
+    locateAll = _locateAll_opencv
+    if not RUNNING_PYTHON_2 and cv2.__version__ < '3':
+        locateAll = _locateAll_python
+else:
+    locateAll = _locateAll_python


### PR DESCRIPTION
pyscreeze.locateAll will use OpenCV tools if the needed libs can be imported, else default to pure python

benefits: faster performance if cv2 and numpy are available (but don't require them as dependencies)
costs: more code to maintain, slightly more RAM needed
limitations: early ~beta status; see doc string in _locateAll_opencv