### PR TITLE
BF: enforce limit in locateAll

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -111,6 +111,7 @@ def locateAll(needleImage, haystackImage, grayscale=None, limit=None, region=Non
                         needleFileObj.close()
                     if haystackFileObj is not None:
                         haystackFileObj.close()
+                    raise StopIteration()
 
 
     # There was no limit or the limit wasn't reached, but close the file handles anyway.


### PR DESCRIPTION
also, a default limit=10000 would be useful (e.g., if accidentally search for an all-white patch in a white
screenshot) but doing that now will introduce a merge conflict with the other branch, so hold off for now.