### PR TITLE
Pick best match for OpenCV locate searches.

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -114,6 +114,7 @@ def _locateAll_opencv(needleImage, haystackImage, grayscale=None, limit=10000, r
     confidence = float(confidence)
 
     needleImage = _load_cv2(needleImage, grayscale)
+    global needleHeight, needleWidth
     needleHeight, needleWidth = needleImage.shape[:2]
     haystackImage = _load_cv2(haystackImage, grayscale)
 
@@ -122,6 +123,8 @@ def _locateAll_opencv(needleImage, haystackImage, grayscale=None, limit=10000, r
                                       region[0]:region[0]+region[2]]
     else:
         region = (0, 0)  # full image; these values used in the yield statement
+    global globalRegion
+    globalRegion = region
     if (haystackImage.shape[0] < needleImage.shape[0] or
         haystackImage.shape[1] < needleImage.shape[1]):
         # avoid semi-cryptic OpenCV error below if bad size
@@ -133,9 +136,13 @@ def _locateAll_opencv(needleImage, haystackImage, grayscale=None, limit=10000, r
         haystackImage = haystackImage[::step, ::step]
     else:
         step = 1
+    global globalStep
+    globalStep = step
 
     # get all matches at once, credit: https://stackoverflow.com/questions/7670112/finding-a-subimage-inside-a-numpy-image/9253805#9253805
+    global result
     result = cv2.matchTemplate(haystackImage, needleImage, cv2.TM_CCOEFF_NORMED)
+    #result = cv2.matchTemplate(haystackImage, needleImage, cv2.TM_SQDIFF_NORMED)
     match_indices = numpy.arange(result.size)[(result > confidence).flatten()]
     matches = numpy.unravel_index(match_indices[:limit], result.shape)
 
@@ -243,7 +250,13 @@ def locate(needleImage, haystackImage, **kwargs):
     kwargs['limit'] = 1
     points = tuple(locateAll(needleImage, haystackImage, **kwargs))
     if len(points) > 0:
-        return points[0]
+        if useOpenCV:
+            min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(result)
+            x = max_loc[0] * globalStep + globalRegion[0]
+            y = max_loc[1] * globalStep + globalRegion[1]
+            return (x, y, needleWidth, needleHeight)
+        else:
+            return points[0]
     else:
         return None
 


### PR DESCRIPTION
There are cases where there is a need to search for image with a lower confidence level, such as cases where the haystackImage is generated with random loss of quality. In such cases, returning the first match is sub-optimal. This pull requests picks best match from all matches found.
Proper implementation will require code refactoring instead of using globals, but this code seems to work.