### PR TITLE
added support for RGBA pixel matching

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -399,10 +399,16 @@ def center(coords):
 
 
 def pixelMatchesColor(x, y, expectedRGBColor, tolerance=0):
-    r, g, b = screenshot().getpixel((x, y))
-    exR, exG, exB = expectedRGBColor
-
-    return (abs(r - exR) <= tolerance) and (abs(g - exG) <= tolerance) and (abs(b - exB) <= tolerance)
+    pixel = screenshot().getpixel((x, y))
+    colors = min(len(pixel), len(expectedRGBColor))
+    if colors == 3: #RGB mode
+        r, g, b = pixel[:3]
+        exR, exG, exB = expectedRGBColor[:3]
+        return (abs(r - exR) <= tolerance) and (abs(g - exG) <= tolerance) and (abs(b - exB) <= tolerance)
+    if colors == 4: #RGBA mode
+        r, g, b, a = pixel
+        exR, exG, exB, exA = expectedRGBColor
+        return (abs(r - exR) <= tolerance) and (abs(g - exG) <= tolerance) and (abs(b - exB) <= tolerance) and (abs(a - exA) <= tolerance)
 
 
 def pixel(x, y):


### PR DESCRIPTION
Sometimes the _screenshot_osx() function returns a image in rgba mode. I don't have a mac, but this was seen by someone I was helping on [/r/learnpython](https://www.reddit.com/r/learnpython/comments/5l674g/somehow_have_too_many_values_to_unpack/), who was using El Capitan 10.6.8 and Python 3.5.1. 

This update checks for the number of arguments the screenshot function returns, and adds the comparison of the alpha value if both the screenshot and the test value include it. 

Please test; I don't have a mac and can't test it well. 