### PR TITLE
Added warning to ImportError for OpenCV

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import time
 import errno
+import warnings
 try:
     from PIL import Image
     from PIL import ImageOps
@@ -29,6 +30,7 @@ try:
     useOpenCV = True
     RUNNING_CV_2 = cv2.__version__[0] < '3'
 except ImportError:
+    warnings.warn("OpenCV module not loaded. For better performance on the Locate functions, install opencv-python")
     useOpenCV = False
 
 RUNNING_PYTHON_2 = sys.version_info[0] == 2


### PR DESCRIPTION
Explicitly warn users OpenCV could not be loaded with clarification on why it matters rather than just silently failing.