### PR TITLE
Fixed home directory expansion and added error handling to osx screenshot

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -324,7 +324,10 @@ def _screenshot_osx(imageFilename=None, region=None):
         tmpFilename = '.screenshot%s.png' % (datetime.datetime.now().strftime('%Y-%m%d_%H-%M-%S-%f'))
     else:
         tmpFilename = imageFilename
-    subprocess.call(['screencapture', '-x', tmpFilename])
+    tmpFilename = os.path.expanduser(tmpFilename)
+    cmd_list = ['screencapture', '-x', tmpFilename]
+    if subprocess.call(cmd_list) != 0:
+        raise(RuntimeError("The command, subprocess.call({}), failed so no screenshot is saved to {}".format(cmd_list,tmpFilename)))
     im = Image.open(tmpFilename)
 
     if region is not None:


### PR DESCRIPTION
Is there any reason to not have the tilde character expand to the home directory? If not, this is a pretty simple change that will be convenient for people like me who would like that behavior.

Is RuntimeError the right exception to raise? I think raising the exception when the screenshot command  returns a non-zero exit code is probably preferable to having an error generated by not being able to find the file that the screenshot command was expected to have created.

I tested this by uninstalling pyscreeze with "pip uninstall", then running "python setup.py install" from my fork of the repository, and testing it out on my macbook. It now expands the tilde to the home directory, as well as raising the exception if the file can't be made.