### PR TITLE
fix cropped image saving on Linux and Mac

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -334,6 +334,8 @@ def _screenshot_osx(imageFilename=None, region=None):
         assert len(region) == 4, 'region argument must be a tuple of four ints'
         region = [int(x) for x in region]
         im = im.crop((region[0], region[1], region[2] + region[0], region[3] + region[1]))
+        os.unlink(tmpFilename) # delete image of entire screen to save cropped version
+        im.save(tmpFilename)
     else:
         # force loading before unlinking, Image.open() is lazy
         im.load()
@@ -358,6 +360,8 @@ def _screenshot_linux(imageFilename=None, region=None):
             assert len(region) == 4, 'region argument must be a tuple of four ints'
             region = [int(x) for x in region]
             im = im.crop((region[0], region[1], region[2] + region[0], region[3] + region[1]))
+            os.unlink(tmpFilename) # delete image of entire screen to save cropped version
+            im.save(tmpFilename)
         else:
             # force loading before unlinking, Image.open() is lazy
             im.load()


### PR DESCRIPTION
As referenced in pyautogui's issue 286 (https://github.com/asweigart/pyautogui/issues/286), currently a call to the screenshot function that includes both a region and filename will save an image of the entire screen to the filesystem, but return a cropped image. 
This change would make the image saved on the filesystem (for osx and linux) also be the cropped version, which is what the user would expect, and mirrors the behavior on win32.