### PR TITLE
fix to pixel function

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -451,7 +451,9 @@ def pixel(x, y):
         b = color // (256 ** 2)
         return (r, g, b)
     else:
-        return RGB(*screenshot().getpixel((x, y)))
+        # Need to select only the first three values of the color in
+        # case the returned pixel has an alpha channel
+        return RGB(*(screenshot().getpixel((x, y))[:3]))
 
 
 # set the screenshot() function based on the platform running this module


### PR DESCRIPTION
So this addresses an issue with pyscreeze when trying to use `pixelMatchesColor` in  pyautogui:

```
pyautogui.pixelMatchesColor(0, 0, c[:3])     
------------------------------------------------------
TypeError            Traceback (most recent call last)
<ipython-input-13-aaec314f6883> in <module>
----> 1 pyautogui.pixelMatchesColor(0, 0, c[:3])

/usr/local/lib/python3.7/site-packages/pyscreeze/__init__.py in pixelMatchesColor(x, y, expectedRGBColor, tolerance)
    429 
    430 def pixelMatchesColor(x, y, expectedRGBColor, tolerance=0):
--> 431     pix = pixel(x, y)
    432     if len(pix) == 3 or len(expectedRGBColor) == 3: #RGB mode
    433         r, g, b = pix[:3]

/usr/local/lib/python3.7/site-packages/pyscreeze/__init__.py in pixel(x, y)
    452         return (r, g, b)
    453     else:
--> 454         return RGB(*screenshot().getpixel((x, y)))
    455 
    456 

TypeError: __new__() takes 4 positional arguments but 5 were given
```

On macOS, the pixel value returned by the screenshot is RBGA. The `pixel(x, y)` function in pyscreeze assumes the pixel color returned by `getpixel` is RGB. This simply selects the first three values.
