### PR TITLE
Fix issue with "which" not being found

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -80,18 +80,9 @@ GRAYSCALE_DEFAULT = False
 USE_IMAGE_NOT_FOUND_EXCEPTION = False
 
 scrotExists = False
-try:
-    if sys.platform not in ('java', 'darwin', 'win32'):
-        whichProc = subprocess.Popen(
-            ['which', 'scrot'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        scrotExists = whichProc.wait() == 0
-except OSError as ex:
-    if ex.errno == errno.ENOENT:
-        # if there is no "which" program to find scrot, then assume there
-        # is no scrot.
-        pass
-    else:
-        raise
+if sys.platform not in ('java', 'darwin', 'win32'):
+    if os.popen('command -v scrot').read():
+        scrotExists = True
 
 
 if sys.platform == 'win32':


### PR DESCRIPTION
Issue is here, and is documented: https://github.com/asweigart/pyscreeze/blob/0446e87235e0079f591f0c49ece7d487dedc2f9a/pyscreeze/__init__.py#L90

I was running a minimal *nix today and using this package. I kept getting a `NotImplementedError` saying `scrot` wasn't installed, but I had already installed it! Figured out by coming to the source code here that it was because `which` wasn't installed.

[This Stack Overflow post](https://stackoverflow.com/a/677212) outlines a POSIX compatible solution by doing `command -v scrot`. Which is interesting, never heard of that. It also talks about why you shouldn't use which. The more you know...

Note because `command` is a shell builtin, I had to use `os.popen` instead of `subprocess.Popen`.

P.S. @asweigart I had no idea you made this package. I read your "Invent Your Own Computer Games with Python" a long time ago & I recommend your "Automate the Boring Stuff with Python" to anyone who asks me how to learn Python. Thanks for everything you do for Python, I appreciate you.