### PR TITLE
Better error message: match signatures for internal functions

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -235,10 +235,13 @@ def _locateAll_opencv(needleImage, haystackImage, grayscale=None, limit=10000, r
 
 # TODO - We should consider renaming _locateAll_python to _locateAll_pillow, since Pillow is the real dependency.
 @requiresPillow
-def _locateAll_python(needleImage, haystackImage, grayscale=None, limit=None, region=None, step=1):
+def _locateAll_python(needleImage, haystackImage, grayscale=None, limit=None, region=None, step=1, confidence=None):
     """
     TODO
     """
+    if confidence is not None:
+        raise TypeError("cv2 is required to use confidence argument")
+
     # setup all the arguments
     if grayscale is None:
         grayscale = GRAYSCALE_DEFAULT


### PR DESCRIPTION
In helping people use this module it often comes up that a user tries to use the confidence argument and receives an unhelpful TypeError when cv2 is not installed. [For example, from today](https://www.reddit.com/r/learnpython/comments/kqbgvd/error_using_confidence_in_pyautogui/). This PR adds a more helpful error message. 