### PR TITLE
Fix pillow version check on macOS

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -524,7 +524,7 @@ def _screenshot_osx(imageFilename=None, region=None):
     TODO
     """
     # TODO - use tmp name for this file.
-    if tuple(PIL__version__) < (6, 2, 1):
+    if tuple(int(i) for i in PIL__version__.split(".")) < (6, 2, 1):
         # Use the screencapture program if Pillow is older than 6.2.1, which
         # is when Pillow supported ImageGrab.grab() on macOS. (It may have
         # supported it earlier than 6.2.1, but I haven't tested it.)


### PR DESCRIPTION
dbe9cb89 introduced a version check using `PIL.__version__` assuming that that attribute is a int-tuple whereas it's really just a string, leading to a type error on even the most basic usage on macOS:

    >>> pyscreeze.screenshot()
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/Users/home/notebooks/pyscreeze/pyscreeze/__init__.py", line 527, in _screenshot_osx
        if tuple(PIL__version__) < (6, 2, 1):
    TypeError: '<' not supported between instances of 'str' and 'int'

Convert the offending version string to an int-tuple.