### PR TITLE
fix: fixed region screenshot for osx

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -549,7 +549,7 @@ def _screenshot_osx(imageFilename=None, region=None):
     TODO
     """
     # TODO - use tmp name for this file.
-    if PILLOW_VERSION < (6, 2, 1):
+    if tuple(map(int, PIL__version__.split("."))) < (6, 2, 1):
         # Use the screencapture program if Pillow is older than 6.2.1, which
         # is when Pillow supported ImageGrab.grab() on macOS. (It may have
         # supported it earlier than 6.2.1, but I haven't tested it.)
@@ -574,7 +574,10 @@ def _screenshot_osx(imageFilename=None, region=None):
             os.unlink(tmpFilename)
     else:
         # Use ImageGrab.grab() to get the screenshot if Pillow version 6.3.2 or later is installed.
-        im = ImageGrab.grab()
+        if region is not None:
+            im = ImageGrab.grab(bbox = (region[0],region[1],region[2]+region[0],region[3]+region[1])) #fixed for taking region
+        else:
+            im = ImageGrab.grab() #when region=None
     return im
 
 


### PR DESCRIPTION
Description: Fixed pyscreeze.screenshot taking full screenshot instead of a region.

Fixes: #104 

This fixes the problem where the `screenshot()` function was taking entire screenshot not region area. Now it takes the region screenshot and full screen screenshot if region not passed.

Conda (test_env) version: 4.12.0
Python version: 3.8.16
OS: macOS 13.5.1 22G90 arm64 

Script used to test:
```
import os
import time
import pyautogui

x1, y1 = 612, 372  # Top-left corner 
x2, y2 = 803, 407  # Bottom-right corner 
download_dir=os.getcwd() #to save the screenshot

for i in range(3):
    print(f"The script is starting in {i+1} seconds.")  #loading time for script - good practice
    time.sleep(1)

img_name = f'screenshot_pyscreeze.png'
screenshot = pyautogui.screenshot(region=(x1, y1, x2 - x1, y2 - y1)) #top left, width,height for the rectangle box
#screenshot = pyautogui.screenshot()
screenshot.save(os.path.join(download_dir, img_name))
```
Screenshot-
![screenshot_pyscreeze](https://github.com/asweigart/pyscreeze/assets/42275050/0b0a922a-f132-4152-8635-de60d6137102)





