### PR TITLE
Add param for locateOnWindow

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -486,11 +486,11 @@ def locateCenterOnScreenNear(image, x, y, **kwargs):
 
 
 @requiresPyGetWindow
-def locateOnWindow(image, title, **kwargs):
+def locateOnWindow(image, title, equal_or_in='in', **kwargs):
     """
     TODO
     """
-    matchingWindows = pygetwindow.getWindowsWithTitle(title)
+    matchingWindows = pygetwindow.getWindowsWithTitle(title, equal_or_in=equal_or_in)
     if len(matchingWindows) == 0:
         raise PyScreezeException('Could not find a window with %s in the title' % (title))
     elif len(matchingWindows) > 1:


### PR DESCRIPTION
For example, when I open both counter-strike and counter-strike 2 windows, then locateOnWindow will have a problem, saying, find multiple windows, actually I match the string is counter-strike, but I find counter-strike and counter-strike 2, I need to match the previous one, find a one with 2 does not need, So I added a function argument, and after testing it on my local computer, it solved the problem.