### PR TITLE
Fix screenshot function to save user specified <imageFilename> on macOS

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -580,6 +580,10 @@ def _screenshot_osx(imageFilename=None, region=None):
         else:
             # Get full screen for screenshot
             im = ImageGrab.grab()
+
+        if imageFilename:
+            im.save(imageFilename)
+
     return im
 
 


### PR DESCRIPTION
### Summary

On macOS, the `screenshot` function was only saving the user specified \<imageFileName> for Pillow versions < 6.2.1.

It now saves user specified files for Pillow versions >= 6.2.1 as well.

### Testing notes

I did not add any tests since `test_pyscreeze.py` already contained a failing `test_screenshot` test.

It contained 2 failing assertions. The 1st one (checking the saved file) now passes with this fix. The  2nd one (comparing size to resolution) still fails but it's a separate issue not related to this change.