### PR TITLE
Replace `which command` subprocesses with shutil.which()

### DIFF
--- a/pyscreeze/__init__.py
+++ b/pyscreeze/__init__.py
@@ -7,10 +7,10 @@ import collections
 import datetime
 import functools
 import os
+import shutil
 import subprocess
 import sys
 import time
-import errno
 
 from contextlib import contextmanager
 
@@ -63,30 +63,12 @@ GRAYSCALE_DEFAULT = True
 USE_IMAGE_NOT_FOUND_EXCEPTION = True
 
 GNOMESCREENSHOT_EXISTS = False
-try:
-    if sys.platform.startswith('linux'):
-        whichProc = subprocess.Popen(['which', 'gnome-screenshot'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        GNOMESCREENSHOT_EXISTS = whichProc.wait() == 0
-except OSError as ex:
-    if ex.errno == errno.ENOENT:
-        # if there is no "which" program to find gnome-screenshot, then assume there
-        # is no gnome-screenshot.
-        pass
-    else:
-        raise
+if sys.platform.startswith('linux'):
+    GNOMESCREENSHOT_EXISTS = shutil.which('gnome-screenshot') is not None
 
 SCROT_EXISTS = False
-try:
-    if sys.platform.startswith('linux'):
-        whichProc = subprocess.Popen(['which', 'scrot'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        SCROT_EXISTS = whichProc.wait() == 0
-except OSError as ex:
-    if ex.errno == errno.ENOENT:
-        # if there is no "which" program to find scrot, then assume there
-        # is no scrot.
-        pass
-    else:
-        raise
+if sys.platform.startswith('linux'):
+    SCROT_EXISTS = shutil.which('scrot') is not None
 
 # On Linux, figure out which window system is being used.
 if sys.platform.startswith('linux'):


### PR DESCRIPTION
This fixes (hidden by default) warnings about the subprocesses' stdout/stderr handles not being closed before being garbage collected:

    > PYTHONWARNINGS=always::Warning pytest
    ...
    ../../../home/brenainn/.pyenv/versions/3.12.0/lib/python3.12/site-packages/pyscreeze/__init__.py:81
      /home/brenainn/.pyenv/versions/3.12.0/lib/python3.12/site-packages/pyscreeze/__init__.py:81: ResourceWarning: unclosed file <_io.BufferedReader name=11>
        whichProc = subprocess.Popen(['which', 'scrot'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
      Enable tracemalloc to get traceback where the object was allocated.
      See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

    ../../../home/brenainn/.pyenv/versions/3.12.0/lib/python3.12/site-packages/pyscreeze/__init__.py:81
      /home/brenainn/.pyenv/versions/3.12.0/lib/python3.12/site-packages/pyscreeze/__init__.py:81: ResourceWarning: unclosed file <_io.BufferedReader name=13>
        whichProc = subprocess.Popen(['which', 'scrot'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
      Enable tracemalloc to get traceback where the object was allocated.
      See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

And it removes the awkwardness of minimal Linux environments that don't have `which` installed.